### PR TITLE
Use glob for parsing imports

### DIFF
--- a/docs/source/instructions.rst
+++ b/docs/source/instructions.rst
@@ -466,8 +466,12 @@ Example::
 
 This dictionary is created by processing the environment JSON files.
 The main file is called ``environment.json``, and it can have include
-directives that pull in additonal json files so that you can split up
-large environments into multiple files.
+directives (using the ``"imports"`` key) that pull in additional json
+files so that you can split up large environments into multiple
+files. The value of the ``"imports"`` is a array of the files that
+should be imported. The files are processed using the `glob
+<https://docs.python.org/2/library/glob.html>`_ library so wildcards
+like ``*`` and ``?`` are handled appropriately.
 
 environment.json::
 

--- a/src/frycook/recipe_template.py
+++ b/src/frycook/recipe_template.py
@@ -535,14 +535,14 @@ class Recipe(object):
         :param target_path: root path on remote server to copy git repo to
         '''
         rsync_command = ('rsync -qrlptz --delete --delete-excluded '
-                         '--exclude=.svn --exclude=.git')
+                         '--exclude=.svn --exclude=.git --rsync-path="sudo rsync"')
         tmp_path = os.path.join(self.settings["tmp_dir"],
                                 'push_git_repo/repo/')
         if not os.path.exists(tmp_path):
             local('git clone %s %s' % (git_url, tmp_path))
         else:
             local('cd %s && git pull' % tmp_path)
-        local('%s %s root@%s:%s' %
+        local('%s %s %s:%s' %
               (rsync_command, tmp_path, computer, target_path))
         cuisine.sudo('chown -R %s:%s %s' % (user, group, target_path))
         shutil.rmtree(tmp_path)

--- a/src/frycooker.py
+++ b/src/frycooker.py
@@ -37,6 +37,7 @@ cookbooks and applies them to computers.
 
 import argparse
 from collections import OrderedDict
+import glob
 import json
 import os
 import shutil
@@ -179,10 +180,11 @@ def load_enviro(filename):
 
     for key in enviro:
         if 'imports' in enviro[key]:
-            for imp_file in enviro[key]['imports']:
-                imp_enviro = load_enviro(imp_file)
-                for imp_key in imp_enviro:
-                    enviro[key][imp_key] = imp_enviro[imp_key]
+            for imp_file_glob in enviro[key]['imports']:
+                for imp_file in glob.iglob(imp_file_glob):
+                    imp_enviro = load_enviro(imp_file)
+                    for imp_key in imp_enviro:
+                        enviro[key][imp_key] = imp_enviro[imp_key]
             del enviro[key]['imports']
 
     return enviro

--- a/src/frycooker.py
+++ b/src/frycooker.py
@@ -36,6 +36,7 @@ cookbooks and applies them to computers.
 '''
 
 import argparse
+from collections import OrderedDict
 import json
 import os
 import shutil
@@ -146,7 +147,7 @@ def load_settings(filename, params):
     :rtype: dictionary
     :return: dictionary representation of settings
     '''
-    settings = json.load(open(filename))
+    settings = json.load(open(filename), object_pairs_hook=OrderedDict)
     settings["params"] = {}
     if params:
         for p in params:
@@ -170,7 +171,7 @@ def load_enviro(filename):
     :return: dictionary representation of environment
     '''
     try:
-        enviro = json.load(open(filename))
+        enviro = json.load(open(filename), object_pairs_hook=OrderedDict)
     except Exception:
         print 'Error reading environment file %s' % filename
         raise

--- a/src/setup.py
+++ b/src/setup.py
@@ -28,11 +28,11 @@
 from distutils.core import setup
 
 setup(name='frycook',
-      version='0.3.9',
+      version='0.4.1',
       description='frycook system builder',
       author='Jay Farrimond',
       author_email='jay@farrimond.com',
-      url='http://github.com/jfarrimo/frycook',
+      url='http://github.com/instaedu/frycook',
       packages=['frycook'],
       scripts=['frycooker.py'],
       install_requires=['fabric', 'cuisine<0.7.6', 'mako'],


### PR DESCRIPTION
This simplifies maintenance by allowing new computer configurations to be added without having to add another line in the `"computers"` key in the environment.